### PR TITLE
NOW Parameter in die SOLR-Query einfügen

### DIFF
--- a/src/Hofff/Contao/Solr/Index/QueryExecutor.php
+++ b/src/Hofff/Contao/Solr/Index/QueryExecutor.php
@@ -20,6 +20,7 @@ class QueryExecutor {
 	public function execute(RequestHandler $handler, Query $query) {
 		$handler->prepareQuery($query);
 		$query->setParam('wt', 'json');
+		$query->setParam('NOW', time() . '000');
 
 		$params = array();
 		foreach($query->getParams() as $key => $values) {


### PR DESCRIPTION
Wie gestern besprochen, fügt dieser PR immer den Parameter NOW an die Query an, so gibt es keine Probleme mehr mit Zeitzonen etc.
